### PR TITLE
Fixed path bug (MAC spoofing works again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 - help             : Displays this area
 - wifiscan         : Performs a WI-FI scan
 - interface	   : Interface management
-- attack           : Attacks on selected WI-FI
+- attack           : Attacks selected WI-FI
 
 
 ## About Brute Forcer

--- a/bruteforcer.cmd
+++ b/bruteforcer.cmd
@@ -24,7 +24,7 @@
 	net session >nul 2>&1
 	if %errorLevel% == 0 (
 		set privilege_level=administrator
-		cd !current_directory!
+		cd /d "%~dp0"
 		if not exist BF_Files\ (
 	              echo The BF_Files folder could not be found.
 	              echo Without it, the program cannot run.

--- a/bruteforcer.cmd
+++ b/bruteforcer.cmd
@@ -1,12 +1,4 @@
 @echo off
-        if not exist BF_Files\ (
-	echo The BF_Files folder could not be found.
-	echo Without it, the program cannot run.
-	echo It may have been renamed, moved or deleted.
-	echo To fix this issue, name the folder back, move it back or reinstall the program from GitHub.
-	pause
-	exit
-	)
 	
 	set allowed_char_list="ABCDEFGHIJKLMNOPRSTUVYZWXQabcdefghijklmnoprstuvyzwxq0123456789-_"
 	title The WI-FI Brute Forcer - Developed By TUX
@@ -33,19 +25,35 @@
 	if %errorLevel% == 0 (
 		set privilege_level=administrator
 		cd !current_directory!
-		cd BF_Files
-		del attempt.xml >nul
-		del infogate.xml >nul
-		cls
-
+		if not exist BF_Files\ (
+	              echo The BF_Files folder could not be found.
+	              echo Without it, the program cannot run.
+	              echo It may have been renamed, moved or deleted.
+	              echo To fix this issue, name the folder back, move it back or reinstall the program from GitHub.
+	              pause
+	              exit
+	        )else (
+	              cd BF_Files
+		      del attempt.xml >nul
+		      del infogate.xml >nul
+		      cls
+		)
 	)else (
 		set privilege_level=local
-		cd BF_Files
-		del attempt.xml >nul
-		del infogate.xml >nul
-		cls
+		if not exist BF_Files\ (
+	              echo The BF_Files folder could not be found.
+	              echo Without it, the program cannot run.
+	              echo It may have been renamed, moved or deleted.
+	              echo To fix this issue, name the folder back, move it back or reinstall the program from GitHub.
+	              pause
+	              exit
+	        )else (
+	              cd BF_Files
+		      del attempt.xml >nul
+		      del infogate.xml >nul
+		      cls
+		)
 	)
-	
 	
 	
 	
@@ -510,7 +518,7 @@
 		
 		echo.
 		echo.
-		call colorchar.exe /0b " Please choice a wifi or cancel(1-!keynumber!)"
+		call colorchar.exe /0b " Please choose a network or cancel(1-!keynumber!)"
 		echo.
 		set choice=
 		call colorchar.exe /0e " wifi"


### PR DESCRIPTION
I have fixed the bug where it checks if the BF_Files folder exists before checking the permissions. MAC spoofing should work again. View my [issue](https://github.com/TechnicalUserX/batch_wifi_brute_forcer/issues/4) for more info.